### PR TITLE
test: de-flake mysql UpdatedAt assertions

### DIFF
--- a/test/update_test.go
+++ b/test/update_test.go
@@ -67,6 +67,11 @@ func (ts *UpdateIntTestSuite) TestUpdateWhenNothingMatchConditions() {
 func (ts *UpdateIntTestSuite) TestUpdateWhenAModelMatchConditions() {
 	product := ts.createProduct("", 0, 0, false, nil)
 
+	// mysql stores timestamps as datetime(3) (millisecond precision), so
+	// without a gap the update's UpdatedAt can land in the same millisecond
+	// as the create and the NotEqual assertion below flakes.
+	time.Sleep(time.Millisecond)
+
 	updated, err := cql.Update[models.Product](
 		context.Background(),
 		ts.db,
@@ -92,6 +97,11 @@ func (ts *UpdateIntTestSuite) TestUpdateWhenAModelMatchConditions() {
 func (ts *UpdateIntTestSuite) TestUpdateWhenMultipleModelsMatchConditions() {
 	product1 := ts.createProduct("1", 0, 0, false, nil)
 	product2 := ts.createProduct("2", 0, 0, false, nil)
+
+	// mysql stores timestamps as datetime(3) (millisecond precision), so
+	// without a gap the update's UpdatedAt can land in the same millisecond
+	// as product2's create and the NotEqual assertions below flake.
+	time.Sleep(time.Millisecond)
 
 	updated, err := cql.Update[models.Product](
 		context.Background(),


### PR DESCRIPTION
Re-opened from #101 with a compliant branch name (`bugfix/` prefix).

## Problem

The `test (mysql)` job flaked on `main`:

```
FAIL: TestCQL/TestUpdateWhenMultipleModelsMatchConditions
    update_test.go:117: Should not be: 1789060342205000
```

## Root cause — flaky timing, not a regression

- The test creates two products, bulk-updates them, and asserts each row's `UpdatedAt` changed (`NotEqual` vs the create timestamp).
- **Only `product2` (last-created) failed; `product1` passed** — inconsistent with an actual bug, which would fail both.
- gorm's mysql driver stores `time.Time` as `datetime(3)` (millisecond precision — the failing value ends in `000`). When `product2`'s create and the bulk update land in the same millisecond, `UpdatedAt.UnixMicro()` is identical and `NotEqual` fails.
- The assertions date to 2023 (`git blame` → `4ba9cbb7`), untouched by the fast scanner work; every other DB passed.

## Fix

Sleep 1ms between the create and the update in the two affected tests so their timestamps can't share a millisecond.

🤖 Generated with [Claude Code](https://claude.com/claude-code)